### PR TITLE
Solution for this error = User Argument passed to call that takes no arguments Cannot infer contextual base in reference to member 'any'

### DIFF
--- a/AR/Views/BrowseView/ModelsByCategoryGridView.swift
+++ b/AR/Views/BrowseView/ModelsByCategoryGridView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+
 struct ModelsByCategoryGridView: View {
     
     @Binding var showBrowse: Bool
@@ -14,21 +15,16 @@ struct ModelsByCategoryGridView: View {
     let models = Models()
     
     var body: some View {
-        
         VStack {
-            
             ForEach(ModelCategory.allCases, id: \.self) { category in
+                // No need for optional binding here
+                let modelsByCategory = models.get(category: category)
                 
-                if let modelsByCategory = models.get(category: category) {
-                    
+                // Check if the array is not empty before creating the HorizontalGridView
+                if !modelsByCategory.isEmpty {
                     HorizontalGridView(showBrowse: $showBrowse, title: category.label, items: modelsByCategory)
-                    
                 }
-                
             }
-            
         }
-        
     }
-    
 }

--- a/AR/Views/UIKit/ARViewRepresentable.swift
+++ b/AR/Views/UIKit/ARViewRepresentable.swift
@@ -32,32 +32,27 @@ struct ARViewRepresentable: UIViewRepresentable {
         
     }
     
-    private func updateScene(for arView: CustomARView)  {
-        
-        arView.focusEntity?.isEnabled  = placementSettings.selectedModel != nil
+    private func updateScene(for arView: CustomARView?) {
+        guard let arView = arView else { return }
         
         if let confirmedModel = placementSettings.confirmedModel, let modelEntity = confirmedModel.modelEntity {
-            
             place(modelEntity, in: arView)
-            
             placementSettings.confirmedModel = nil
-            
         }
-        
     }
-    
     private func place(_ modelEntity: ModelEntity, in arView: ARView) {
-        
         let clonedEntity = modelEntity.clone(recursive: true)
         clonedEntity.generateCollisionShapes(recursive: true)
         
         arView.installGestures([.translation, .rotation], for: clonedEntity)
         
-        let anchorEntity = AnchorEntity(plane: .any)
-        anchorEntity.addChild(clonedEntity)
-        
-        arView.scene.addAnchor(anchorEntity)
-                
+        // Raycast to detect a plane
+        if let raycastResult = arView.raycast(from: arView.center, allowing: .existingPlaneGeometry, alignment: .horizontal).first {
+            let anchorEntity = AnchorEntity(world: raycastResult.worldTransform)
+            anchorEntity.addChild(clonedEntity)
+            arView.scene.addAnchor(anchorEntity)
+        }
     }
-    
 }
+
+


### PR DESCRIPTION

import Foundation
import RealityKit
import SwiftUI

struct ARViewRepresentable: UIViewRepresentable {
    
    @EnvironmentObject var placementSettings: PlacementSettings
    @EnvironmentObject var sessionSettings: SessionSettings
    
    func makeUIView(context: Context) -> CustomARView {
        
        let arView = CustomARView(frame: .zero, sessionSettings: sessionSettings)
        
        placementSettings.sceneObserver = arView.scene.subscribe(to: SceneEvents.Update.self, { event in
            
            updateScene(for: arView)
            
        })
        
        return arView
        
    }
    
    func updateUIView(_ uiView: CustomARView, context: Context) {
        
    }
    
    private func updateScene(for arView: CustomARView?) {
        guard let arView = arView else { return }
        
        if let confirmedModel = placementSettings.confirmedModel, let modelEntity = confirmedModel.modelEntity {
            place(modelEntity, in: arView)
            placementSettings.confirmedModel = nil
        }
    }
    private func place(_ modelEntity: ModelEntity, in arView: ARView) {
        let clonedEntity = modelEntity.clone(recursive: true)
        clonedEntity.generateCollisionShapes(recursive: true)
        
        arView.installGestures([.translation, .rotation], for: clonedEntity)
        
        // Raycast to detect a plane
        if let raycastResult = arView.raycast(from: arView.center, allowing: .existingPlaneGeometry, alignment: .horizontal).first {
            let anchorEntity = AnchorEntity(world: raycastResult.worldTransform)
            anchorEntity.addChild(clonedEntity)
            arView.scene.addAnchor(anchorEntity)
        }
    }
}

